### PR TITLE
Fix stray diff marker in ChatGPTClient stop tokens

### DIFF
--- a/src/ChatGPTClient.js
+++ b/src/ChatGPTClient.js
@@ -108,7 +108,6 @@ export default class ChatGPTClient {
                 stopTokens.push(this.endToken);
             }
             stopTokens.push(`\n${this.userLabel}:`);
-            stopTokens.push('<|diff_marker|>');
             // I chose not to do one for `chatGptLabel` because I've never seen it happen
             this.modelOptions.stop = stopTokens;
         }


### PR DESCRIPTION
## Summary
- remove extraneous `diff_marker` token from ChatGPTClient

## Testing
- `npx eslint .` *(fails: ESLint couldn't find configuration)*