### PR TITLE
Add experimental DeepSeek client

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Discord user @pig#8932 has found a working `text-chat-davinci-002` model, `text-
   - Includes a built-in jailbreak you can activate which enables unlimited chat messages per conversation, unlimited messages per day, and brings Sydney back. 😊 
 - `ChatGPTBrowserClient`: support for the official ChatGPT website, using a reverse proxy server for a Cloudflare bypass.
   - **There may be a high chance of your account being banned if you continue to automate chat.openai.com.** Continue doing so at your own risk.
+- `DeepSeekClient`: experimental support for the DeepSeek API (assumes OpenAI compatible endpoints).
 
 ## Getting Started
 
@@ -242,7 +243,7 @@ module.exports = {
         host: process.env.API_HOST || 'localhost',
         // (Optional) Set to true to enable `console.debug()` logging
         debug: false,
-        // (Optional) Possible options: "chatgpt", "chatgpt-browser", "bing". (Default: "chatgpt")
+        // (Optional) Possible options: "chatgpt", "chatgpt-browser", "bing", "deepseek". (Default: "chatgpt")
         clientToUse: 'chatgpt',
         // (Optional) Generate titles for each conversation for clients that support it (only ChatGPTClient for now).
         // This will be returned as a `title` property in the first response of the conversation.
@@ -271,7 +272,7 @@ module.exports = {
     },
     // Options for the CLI app
     cliOptions: {
-        // (Optional) Possible options: "chatgpt", "bing".
+        // (Optional) Possible options: "chatgpt", "bing", "deepseek".
         // clientToUse: 'bing',
     },
 };

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -9,6 +9,7 @@ import inquirer from 'inquirer';
 import inquirerAutocompletePrompt from 'inquirer-autocomplete-prompt';
 import ChatGPTClient from '../src/ChatGPTClient.js';
 import BingAIClient from '../src/BingAIClient.js';
+import DeepSeekClient from '../src/DeepSeekClient.js';
 
 const arg = process.argv.find(_arg => _arg.startsWith('--settings'));
 const path = arg?.split('=')[1] ?? './settings.js';
@@ -81,6 +82,13 @@ switch (clientToUse) {
             cache: settings.cacheOptions,
         });
         break;
+    case 'deepseek':
+        client = new DeepSeekClient(
+            settings.deepseekApiKey || settings.deepseekClient?.apiKey,
+            settings.deepseekClient,
+            settings.cacheOptions,
+        );
+        break;
     default:
         client = new ChatGPTClient(
             settings.openaiApiKey || settings.chatGptClient.openaiApiKey,
@@ -152,6 +160,9 @@ async function onMessage(message) {
     switch (clientToUse) {
         case 'bing':
             aiLabel = 'Bing';
+            break;
+        case 'deepseek':
+            aiLabel = 'DeepSeek';
             break;
         default:
             aiLabel = settings.chatGptClient?.chatGptLabel || 'ChatGPT';
@@ -252,7 +263,7 @@ async function newConversation() {
 }
 
 async function deleteAllConversations() {
-    if (clientToUse !== 'chatgpt') {
+    if (clientToUse !== 'chatgpt' && clientToUse !== 'deepseek') {
         logWarning('Deleting all conversations is only supported for ChatGPT client.');
         return conversation();
     }
@@ -262,7 +273,7 @@ async function deleteAllConversations() {
 }
 
 async function copyConversation() {
-    if (clientToUse !== 'chatgpt') {
+    if (clientToUse !== 'chatgpt' && clientToUse !== 'deepseek') {
         logWarning('Copying conversations is only supported for ChatGPT client.');
         return conversation();
     }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import ChatGPTClient from './src/ChatGPTClient.js';
 import ChatGPTBrowserClient from './src/ChatGPTBrowserClient.js';
 import BingAIClient from './src/BingAIClient.js';
+import DeepSeekClient from './src/DeepSeekClient.js';
 
-export { ChatGPTClient, ChatGPTBrowserClient, BingAIClient };
+export { ChatGPTClient, ChatGPTBrowserClient, BingAIClient, DeepSeekClient };
 export default ChatGPTClient;

--- a/settings.example.js
+++ b/settings.example.js
@@ -62,6 +62,18 @@ export default {
         // (Optional) Set to true to enable `console.debug()` logging
         debug: false,
     },
+    deepseekClient: {
+        // Your DeepSeek API key
+        apiKey: process.env.DEEPSEEK_API_KEY || '',
+        // Optional reverse proxy URL
+        // reverseProxyUrl: '',
+        // (Optional) Default model name
+        modelOptions: {
+            model: 'deepseek-chat',
+        },
+        proxy: '',
+        debug: false,
+    },
     // Options for the API server
     apiOptions: {
         port: process.env.API_PORT || 3000,
@@ -78,7 +90,7 @@ export default {
         perMessageClientOptionsWhitelist: {
             // The ability to switch clients using `clientOptions.clientToUse` will be disabled if `validClientsToUse` is not set.
             // To allow switching clients per message, you must set `validClientsToUse` to a non-empty array.
-            validClientsToUse: ['bing', 'chatgpt', 'chatgpt-browser'], // values from possible `clientToUse` options above
+            validClientsToUse: ['bing', 'chatgpt', 'chatgpt-browser', 'deepseek'], // values from possible `clientToUse` options above
             // The Object key, e.g. "chatgpt", is a value from `validClientsToUse`.
             // If not set, ALL options will be ALLOWED to be changed. For example, `bing` is not defined in `perMessageClientOptionsWhitelist` above,
             // so all options for `bingAiClient` will be allowed to be changed.
@@ -93,11 +105,14 @@ export default {
                 // If you want to allow changing all `modelOptions`, define `modelOptions` here instead of `modelOptions.temperature`.
                 'modelOptions.temperature',
             ],
+            deepseek: [
+                'modelOptions.temperature',
+            ],
         },
     },
     // Options for the CLI app
     cliOptions: {
-        // (Optional) Possible options: "chatgpt", "bing".
+        // (Optional) Possible options: "chatgpt", "bing", "deepseek".
         // clientToUse: 'bing',
     },
 };

--- a/src/DeepSeekClient.js
+++ b/src/DeepSeekClient.js
@@ -1,0 +1,17 @@
+import ChatGPTClient from './ChatGPTClient.js';
+
+export default class DeepSeekClient extends ChatGPTClient {
+    setOptions(options) {
+        super.setOptions(options);
+        const modelOptions = this.options.modelOptions || {};
+        // default model for DeepSeek
+        this.modelOptions.model = modelOptions.model || 'deepseek-chat';
+        // Override completions URL if reverseProxyUrl not specified
+        if (this.options.reverseProxyUrl) {
+            this.completionsUrl = this.options.reverseProxyUrl;
+        } else {
+            this.completionsUrl = 'https://api.deepseek.com/v1/chat/completions';
+        }
+        return this;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DeepSeekClient` extending `ChatGPTClient`
- export the new client
- allow API server and CLI to use the `deepseek` client
- document deepseek options in `settings.example.js`
- mention DeepSeek support in README

## Testing
- `npm test` *(fails: ESLint couldn't find configuration)*